### PR TITLE
HeatmapWindow.js: Use local ip for database connection

### DIFF
--- a/taflab-heatmap-frontend/src/HeatmapWindow.js
+++ b/taflab-heatmap-frontend/src/HeatmapWindow.js
@@ -42,7 +42,7 @@ const HeatmapWindow = () => {
         }
       `;
       try {
-        const response = await fetch("http://64.181.236.184:5000/graphql/boat_data", {
+        const response = await fetch("/graphql/boat_data", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ query }),


### PR DESCRIPTION
Remove public ip of the database. If the front end will be running on the oracle db then we can just use the local address instead of the public IP